### PR TITLE
Switch Python version and add setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # chi-editor
+
 The molecule editor in the Project Chi software package, currently in early development.
+
+## Preparations
+
+Firstly, ensure that you have an installed Python 3.10. If you don't, get the one, [Python 3.10.8](https://www.python.org/downloads/release/python-3108/) for example.
+
+After that, you need to set up Poetry: you can find all instructions [here](https://python-poetry.org/docs/#installation).
+
+## Setup
+
+Clone the repository and open the terminal inside it, after that, run this:
+
+```shell
+poetry install
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 packages = [{include = "chi_editor"}]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "3.10.*"
 pyqt6 = "^6.4.0"
 sqlalchemy = "^1.4.42"
 requests = "^2.28.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ packages = [{include = "chi_editor"}]
 [tool.poetry.dependencies]
 python = "3.10.*"
 pyqt6 = "^6.4.0"
+rdkit = "^2022.9.1"
+datamol = "^0.8.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ packages = [{include = "chi_editor"}]
 [tool.poetry.dependencies]
 python = "3.10.*"
 pyqt6 = "^6.4.0"
-sqlalchemy = "^1.4.42"
-requests = "^2.28.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,11 @@ pyqt6 = "^6.4.0"
 rdkit = "^2022.9.1"
 datamol = "^0.8.4"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
+flake8 = "^5.0.4"
+mypy = "^0.990"
 pytest = "^7.2.0"
-pytest-mock = "*"
+pytest-mock = "^3.10.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
We chose **[datamol](https://datamol.io/)** as a chemistry back-end library. The problem is that it doesn't support Python 3.11 yet, so we need to switch to Python 3.10. Moreover, this PR contains updated dependencies, both package and development.