### PR TITLE
Create layout for solving tasks and tools for switching between layouts

### DIFF
--- a/chi_editor/bases/menu_tool.py
+++ b/chi_editor/bases/menu_tool.py
@@ -17,7 +17,7 @@ class MenuTool(QAction):
 
         self.setText(self.text_asset)
 
-        self.triggered().connect(self.exec())
+        self.triggered.connect(self.exec)
 
     def exec(self) -> None:
         pass

--- a/chi_editor/bases/menu_tool.py
+++ b/chi_editor/bases/menu_tool.py
@@ -1,22 +1,33 @@
 from PyQt6.QtGui import QAction, QIcon
 
-from ..canvas import Canvas
 from ..constants import RESOURCES
+from ..editor import Editor
 
 
 class MenuTool(QAction):
-    def __init__(self, *args, canvas: Canvas, **kwargs) -> None:
+    _editor: Editor
+    
+    def __init__(self, *args, editor: Editor, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.canvas = canvas
+        self._editor = editor
 
         icon_path = RESOURCES / 'assets' / 'toolbar' / f'{self.asset}.png'
         if icon_path.exists():
             self.setIcon(QIcon(str(icon_path)))
 
-    def activate(self, event: QAction.ActionEvent) -> None:
+        self.setText(self.text_asset)
+
+        self.triggered().connect(self.exec())
+
+    def exec(self) -> None:
         pass
 
     @property
     def asset(self) -> str:
-        """Returns the name of the icon for this tool without extension."""
+        """Returns the name of the icon for this menu tool without extension."""
+        raise NotImplemented
+
+    @property
+    def text_asset(self) -> str:
+        """Returns the text of this tool."""
         raise NotImplemented

--- a/chi_editor/bases/menu_tool.py
+++ b/chi_editor/bases/menu_tool.py
@@ -1,0 +1,22 @@
+from PyQt6.QtGui import QAction, QIcon
+
+from ..canvas import Canvas
+from ..constants import RESOURCES
+
+
+class MenuTool(QAction):
+    def __init__(self, *args, canvas: Canvas, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.canvas = canvas
+
+        icon_path = RESOURCES / 'assets' / 'toolbar' / f'{self.asset}.png'
+        if icon_path.exists():
+            self.setIcon(QIcon(str(icon_path)))
+
+    def activate(self, event: QAction.ActionEvent) -> None:
+        pass
+
+    @property
+    def asset(self) -> str:
+        """Returns the name of the icon for this tool without extension."""
+        raise NotImplemented

--- a/chi_editor/bases/menu_tool.py
+++ b/chi_editor/bases/menu_tool.py
@@ -1,13 +1,17 @@
+from typing import TYPE_CHECKING
+
 from PyQt6.QtGui import QAction, QIcon
 
 from ..constants import RESOURCES
-from ..editor import Editor
+
+if TYPE_CHECKING:
+    from ..editor import Editor
 
 
 class MenuTool(QAction):
-    _editor: Editor
-    
-    def __init__(self, *args, editor: Editor, **kwargs) -> None:
+    _editor: "Editor"
+
+    def __init__(self, *args, editor: "Editor", **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._editor = editor
 

--- a/chi_editor/canvas.py
+++ b/chi_editor/canvas.py
@@ -9,7 +9,7 @@ Tool = TypeVar('Tool')
 
 
 class Canvas(QGraphicsScene):
-    current_action: Tool
+    current_action: Tool = None
     min_scene_rect: QRectF
 
     def __init__(self, *args, **kwargs) -> None:
@@ -17,13 +17,16 @@ class Canvas(QGraphicsScene):
         self.min_scene_rect = super().sceneRect()
 
     def mousePressEvent(self, event: QGraphicsSceneMouseEvent) -> None:
-        self.current_action.mouse_press_event(event)
+        if self.current_action:
+            self.current_action.mouse_press_event(event)
 
     def mouseMoveEvent(self, event: QGraphicsSceneMouseEvent) -> None:
-        self.current_action.mouse_move_event(event)
+        if self.current_action:
+            self.current_action.mouse_move_event(event)
 
     def mouseReleaseEvent(self, event: QGraphicsSceneMouseEvent) -> None:
-        self.current_action.mouse_release_event(event)
+        if self.current_action:
+            self.current_action.mouse_release_event(event)
 
     def sceneRect(self) -> QRectF:
         return self.min_scene_rect

--- a/chi_editor/editor.py
+++ b/chi_editor/editor.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 from PyQt6.QtCore import Qt, QRectF
 from PyQt6.QtGui import QIcon, QTransform
-from PyQt6.QtWidgets import QMainWindow, QGraphicsView, QPushButton, QVBoxLayout, QHBoxLayout, QWidget
+from PyQt6.QtWidgets import QMainWindow, QGraphicsView, QPushButton, QVBoxLayout, QWidget, QLayout
 
 from .canvas import Canvas
 from .constants import ASSETS
@@ -42,47 +42,9 @@ class Editor(QMainWindow):
 
         # The biggest part of interface
         self.workspace = QWidget()  # create workspace
-
-        # Initialize QGraphicsView
-        self.graphics_view = QGraphicsView(self)    # create QGraphicsView
-        self.graphics_view\
-            .setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)     # Set QGraphicsView position
-        self.graphics_view.setViewportUpdateMode(QGraphicsView.ViewportUpdateMode.FullViewportUpdate)
-
-        # Initialize GGraphicsScene called canvas
-        self.canvas = Canvas(QRectF(self.graphics_view.geometry()))
-
-        # Bind GraphicsScene to GraphicsView
-        self.graphics_view.setScene(self.canvas)
-
-        h_button_group = QHBoxLayout(self)
-
-        # Box contains magnifying glass
-        v_button_group = QVBoxLayout(self)
-        v_button_group.addStretch(1)
-        v_button_group.setAlignment(Qt.AlignmentFlag.AlignRight)
-
-        scale_plus = QPushButton("Zoom In", self)
-        scale_plus.clicked.connect(self.zoom_in)
-
-        scale_minus = QPushButton("Zoom Out", self)
-        scale_minus.clicked.connect(self.zoom_out)
-
-        v_button_group.addWidget(scale_minus)
-        v_button_group.addWidget(scale_plus)
-        v_button_group.addStretch(1)
-
-        h_button_group.addStretch()
-        h_button_group.addLayout(v_button_group)
-        h_button_group.setAlignment(Qt.AlignmentFlag.AlignCenter)
-
-        layout = QVBoxLayout(self)
-        layout.addWidget(self.graphics_view)
-
-        self.graphics_view.setLayout(h_button_group)
-
-        self.workspace.setLayout(layout)
         self.setCentralWidget(self.workspace)
+
+        self.workspace.setLayout(self.getLayout(Editor.EditorMode.FREE_MODE))
 
         # Add left toolbar
         self.addToolBar(Qt.ToolBarArea.LeftToolBarArea, CanvasToolBar(canvas=self.canvas))
@@ -103,5 +65,49 @@ class Editor(QMainWindow):
         new_scale = current_scale / 1.2
         self.graphics_view.setTransform(QTransform.fromScale(new_scale, new_scale))
 
-    def switchMode(self, mode: EditorMode) -> None:
-        pass
+        # Add left toolbar
+        self.addToolBar(Qt.ToolBarArea.LeftToolBarArea, CanvasToolBar(canvas=self.canvas))
+
+    def getLayout(self, mode: EditorMode) -> QLayout:
+        match mode:
+            case Editor.EditorMode.FREE_MODE:
+                return self.getFreeModeLayout()
+            case Editor.EditorMode.SOLVE_MODE:
+                pass
+            case Editor.EditorMode.CREATE_MODE:
+                pass
+
+    def getFreeModeLayout(self) -> QLayout:
+        # Initialize QGraphicsView
+        self.graphics_view = QGraphicsView(self)  # create QGraphicsView
+        self.graphics_view \
+            .setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)  # Set QGraphicsView position
+        self.graphics_view.setViewportUpdateMode(QGraphicsView.ViewportUpdateMode.FullViewportUpdate)
+
+        # Initialize GGraphicsScene called canvas
+        self.canvas = Canvas(QRectF(self.graphics_view.geometry()))
+
+        # Bind GraphicsScene to GraphicsView
+        self.graphics_view.setScene(self.canvas)
+
+        # Box contains magnifying glass
+        v_button_group = QVBoxLayout(self)
+        v_button_group.addStretch(1)
+        v_button_group.setAlignment(Qt.AlignmentFlag.AlignRight)
+
+        scale_plus = QPushButton("Zoom In", self)
+        scale_plus.clicked.connect(self.zoom_in)
+
+        scale_minus = QPushButton("Zoom Out", self)
+        scale_minus.clicked.connect(self.zoom_out)
+
+        v_button_group.addWidget(scale_minus)
+        v_button_group.addWidget(scale_plus)
+        v_button_group.addStretch(1)
+
+        self.graphics_view.setLayout(v_button_group)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.graphics_view)
+        return layout
+   

--- a/chi_editor/editor.py
+++ b/chi_editor/editor.py
@@ -34,6 +34,7 @@ class Editor(QMainWindow):
 
     # Toolbar that contains tools for manipulating canvas in free mode
     toolbars: list[QToolBar]
+    mode: EditorMode
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -66,6 +67,7 @@ class Editor(QMainWindow):
                 toolbar.toggleViewAction().setChecked(False)
                 toolbar.toggleViewAction().trigger()
         _solver_tool_bar.toggleViewAction().trigger()
+        self.mode = 0
 
     def zoom_in(self):
         # Get the current scale factor of the view
@@ -84,10 +86,11 @@ class Editor(QMainWindow):
         self.view_free.setTransform(QTransform.fromScale(new_scale, new_scale))
 
     def setMode(self, mode: EditorMode) -> None:
-        self.toolbars[self.workspace.currentIndex()].toggleViewAction().trigger()
+        self.toolbars[self.mode].toggleViewAction().trigger()
         self.workspace.widget(self.workspace.currentIndex()).hide()
         self.workspace.widget(mode.value).show()
         self.toolbars[mode.value].toggleViewAction().trigger()
+        self.mode = mode.value
 
     def createModes(self) -> None:
         self.workspace.addWidget(self.getFreeModeLayout())

--- a/chi_editor/editor.py
+++ b/chi_editor/editor.py
@@ -44,8 +44,6 @@ class Editor(QMainWindow):
         self.workspace = QWidget()  # create workspace
         self.setCentralWidget(self.workspace)
 
-        self.workspace.setLayout(self.getLayout(Editor.EditorMode.FREE_MODE))
-
         # Add left toolbar
         self.addToolBar(Qt.ToolBarArea.LeftToolBarArea, CanvasToolBar(canvas=self.canvas))
 
@@ -68,10 +66,10 @@ class Editor(QMainWindow):
         # Add left toolbar
         self.addToolBar(Qt.ToolBarArea.LeftToolBarArea, CanvasToolBar(canvas=self.canvas))
 
-    def getLayout(self, mode: EditorMode) -> QLayout:
+    def setMode(self, mode: EditorMode) -> None:
         match mode:
             case Editor.EditorMode.FREE_MODE:
-                return self.getFreeModeLayout()
+                self.workspace.setLayout(self.getFreeModeLayout())
             case Editor.EditorMode.SOLVE_MODE:
                 pass
             case Editor.EditorMode.CREATE_MODE:

--- a/chi_editor/editor.py
+++ b/chi_editor/editor.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from PyQt6.QtCore import Qt, QRectF
 from PyQt6.QtGui import QIcon, QTransform
 from PyQt6.QtWidgets import QMainWindow, QGraphicsView, QPushButton, QVBoxLayout, QHBoxLayout, QWidget
@@ -8,6 +10,10 @@ from .toolbar import CanvasToolBar
 
 
 class Editor(QMainWindow):
+    class EditorMode(Enum):
+        FREE_MODE = 0,
+        SOLVE_MODE = 1,
+        CREATE_MODE = 2
 
     # Hierarchy:
     #
@@ -96,3 +102,6 @@ class Editor(QMainWindow):
         # Update the scale factor of the view
         new_scale = current_scale / 1.2
         self.graphics_view.setTransform(QTransform.fromScale(new_scale, new_scale))
+
+    def switchMode(self, mode: EditorMode) -> None:
+        pass

--- a/chi_editor/editor.py
+++ b/chi_editor/editor.py
@@ -7,14 +7,12 @@ from PyQt6.QtWidgets import QMainWindow, QGraphicsView, QPushButton, QVBoxLayout
 from .canvas import Canvas
 from .constants import ASSETS
 from .toolbar import CanvasToolBar
+from .menubar.menubar import CanvasMenuBar
+
+from .editor_mode import EditorMode
 
 
 class Editor(QMainWindow):
-    class EditorMode(Enum):
-        FREE_MODE = 0
-        SOLVE_MODE = 1
-        CREATE_MODE = 2
-
     # Hierarchy:
     #
     #   window:
@@ -52,7 +50,6 @@ class Editor(QMainWindow):
         self.workspace.widget(0).show()
 
         # Add custom menuBar
-        from .menubar.menubar import CanvasMenuBar
         menubar = CanvasMenuBar(editor=self)
         self.setMenuBar(menubar)
 

--- a/chi_editor/editor_mode.py
+++ b/chi_editor/editor_mode.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class EditorMode(Enum):
+    FREE_MODE = 0
+    SOLVE_MODE = 1
+    CREATE_MODE = 2

--- a/chi_editor/menubar/menu_tools/__init__.py
+++ b/chi_editor/menubar/menu_tools/__init__.py
@@ -1,5 +1,8 @@
+from .create_task import CreateTask
+from .solve_task import SolveTask
 from ...bases.menu_tool import MenuTool
 
 menu_tools: tuple[type[MenuTool], ...] = (
-
+    CreateTask,
+    SolveTask
 )

--- a/chi_editor/menubar/menu_tools/__init__.py
+++ b/chi_editor/menubar/menu_tools/__init__.py
@@ -1,8 +1,10 @@
 from .create_task import CreateTask
 from .solve_task import SolveTask
+from .free_mode import FreeMode
 from ...bases.menu_tool import MenuTool
 
 menu_tools: tuple[type[MenuTool], ...] = (
     CreateTask,
-    SolveTask
+    SolveTask,
+    FreeMode,
 )

--- a/chi_editor/menubar/menu_tools/__init__.py
+++ b/chi_editor/menubar/menu_tools/__init__.py
@@ -1,0 +1,5 @@
+from ...bases.menu_tool import MenuTool
+
+menu_tools: tuple[type[MenuTool], ...] = (
+
+)

--- a/chi_editor/menubar/menu_tools/create_task.py
+++ b/chi_editor/menubar/menu_tools/create_task.py
@@ -1,11 +1,10 @@
 from ...bases.menu_tool import MenuTool
-
-from ...editor import Editor
+from ...editor_mode import EditorMode
 
 
 class CreateTask(MenuTool):
     def exec(self) -> None:
-        self._editor.setMode(Editor.EditorMode.CREATE_MODE)
+        self._editor.setMode(EditorMode.CREATE_MODE)
 
     @property
     def asset(self) -> str:

--- a/chi_editor/menubar/menu_tools/create_task.py
+++ b/chi_editor/menubar/menu_tools/create_task.py
@@ -1,9 +1,11 @@
 from ...bases.menu_tool import MenuTool
 
+from ...editor import Editor
+
 
 class CreateTask(MenuTool):
     def exec(self) -> None:
-        pass
+        self._editor.setMode(Editor.EditorMode.CREATE_MODE)
 
     @property
     def asset(self) -> str:

--- a/chi_editor/menubar/menu_tools/create_task.py
+++ b/chi_editor/menubar/menu_tools/create_task.py
@@ -9,7 +9,7 @@ class CreateTask(MenuTool):
 
     @property
     def asset(self) -> str:
-        raise NotImplemented
+        return ""
 
     @property
     def text_asset(self) -> str:

--- a/chi_editor/menubar/menu_tools/create_task.py
+++ b/chi_editor/menubar/menu_tools/create_task.py
@@ -1,0 +1,14 @@
+from ...bases.menu_tool import MenuTool
+
+
+class CreateTask(MenuTool):
+    def exec(self) -> None:
+        pass
+
+    @property
+    def asset(self) -> str:
+        raise NotImplemented
+
+    @property
+    def text_asset(self) -> str:
+        return "Create task"

--- a/chi_editor/menubar/menu_tools/free_mode.py
+++ b/chi_editor/menubar/menu_tools/free_mode.py
@@ -1,9 +1,11 @@
 from ...bases.menu_tool import MenuTool
 
+from ...editor import Editor
+
 
 class FreeMode(MenuTool):
     def exec(self) -> None:
-        pass
+        self._editor.setMode(Editor.EditorMode.FREE_MODE)
 
     @property
     def asset(self) -> str:

--- a/chi_editor/menubar/menu_tools/free_mode.py
+++ b/chi_editor/menubar/menu_tools/free_mode.py
@@ -1,11 +1,10 @@
 from ...bases.menu_tool import MenuTool
-
-from ...editor import Editor
+from ...editor_mode import EditorMode
 
 
 class FreeMode(MenuTool):
     def exec(self) -> None:
-        self._editor.setMode(Editor.EditorMode.FREE_MODE)
+        self._editor.setMode(EditorMode.FREE_MODE)
 
     @property
     def asset(self) -> str:

--- a/chi_editor/menubar/menu_tools/free_mode.py
+++ b/chi_editor/menubar/menu_tools/free_mode.py
@@ -9,7 +9,7 @@ class FreeMode(MenuTool):
 
     @property
     def asset(self) -> str:
-        raise NotImplemented
+        return ""
 
     @property
     def text_asset(self) -> str:

--- a/chi_editor/menubar/menu_tools/free_mode.py
+++ b/chi_editor/menubar/menu_tools/free_mode.py
@@ -1,0 +1,14 @@
+from ...bases.menu_tool import MenuTool
+
+
+class FreeMode(MenuTool):
+    def exec(self) -> None:
+        pass
+
+    @property
+    def asset(self) -> str:
+        raise NotImplemented
+
+    @property
+    def text_asset(self) -> str:
+        return "Enter free mode"

--- a/chi_editor/menubar/menu_tools/solve_task.py
+++ b/chi_editor/menubar/menu_tools/solve_task.py
@@ -1,11 +1,10 @@
 from ...bases.menu_tool import MenuTool
-
-from ...editor import Editor
+from ...editor_mode import EditorMode
 
 
 class SolveTask(MenuTool):
     def exec(self) -> None:
-        self._editor.setMode(Editor.EditorMode.SOLVE_MODE)
+        self._editor.setMode(EditorMode.SOLVE_MODE)
 
     @property
     def asset(self) -> str:

--- a/chi_editor/menubar/menu_tools/solve_task.py
+++ b/chi_editor/menubar/menu_tools/solve_task.py
@@ -1,9 +1,11 @@
 from ...bases.menu_tool import MenuTool
 
+from ...editor import Editor
+
 
 class SolveTask(MenuTool):
     def exec(self) -> None:
-        pass
+        self._editor.setMode(Editor.EditorMode.SOLVE_MODE)
 
     @property
     def asset(self) -> str:

--- a/chi_editor/menubar/menu_tools/solve_task.py
+++ b/chi_editor/menubar/menu_tools/solve_task.py
@@ -1,0 +1,14 @@
+from ...bases.menu_tool import MenuTool
+
+
+class SolveTask(MenuTool):
+    def exec(self) -> None:
+        pass
+
+    @property
+    def asset(self) -> str:
+        raise NotImplemented
+
+    @property
+    def text_asset(self) -> str:
+        return "Solve task"

--- a/chi_editor/menubar/menu_tools/solve_task.py
+++ b/chi_editor/menubar/menu_tools/solve_task.py
@@ -9,7 +9,7 @@ class SolveTask(MenuTool):
 
     @property
     def asset(self) -> str:
-        raise NotImplemented
+        return ""
 
     @property
     def text_asset(self) -> str:

--- a/chi_editor/menubar/menubar.py
+++ b/chi_editor/menubar/menubar.py
@@ -13,5 +13,5 @@ class CanvasMenuBar(QMenuBar):
 
         mode_menu = self.addMenu("Mode")
         for MenuTool in menu_tools:
-            menu_tool = MenuTool(editor=editor)
+            menu_tool = MenuTool(editor=editor, parent=mode_menu)
             mode_menu.addAction(menu_tool)

--- a/chi_editor/menubar/menubar.py
+++ b/chi_editor/menubar/menubar.py
@@ -1,13 +1,17 @@
-from PyQt6.QtGui import QAction, QActionGroup
 from PyQt6.QtWidgets import QMenuBar
 
+from ..editor import Editor
 from .menu_tools import menu_tools
-from ..canvas import Canvas
 
 
 class CanvasMenuBar(QMenuBar):
-    _canvas: Canvas
+    _editor: Editor
 
-    def __init__(self, *args, canvas: Canvas, **kwargs) -> None:
+    def __init__(self, *args, editor: Editor, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._canvas = canvas
+        self._editor = editor
+
+        mode_menu = self.addMenu("Mode")
+        for MenuTool in menu_tools:
+            menu_tool = MenuTool(editor=editor)
+            mode_menu.addAction(menu_tool)

--- a/chi_editor/menubar/menubar.py
+++ b/chi_editor/menubar/menubar.py
@@ -1,0 +1,13 @@
+from PyQt6.QtGui import QAction, QActionGroup
+from PyQt6.QtWidgets import QMenuBar
+
+from .menu_tools import menu_tools
+from ..canvas import Canvas
+
+
+class CanvasMenuBar(QMenuBar):
+    _canvas: Canvas
+
+    def __init__(self, *args, canvas: Canvas, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._canvas = canvas

--- a/chi_editor/menubar/menubar.py
+++ b/chi_editor/menubar/menubar.py
@@ -1,13 +1,17 @@
+from typing import TYPE_CHECKING
+
 from PyQt6.QtWidgets import QMenuBar
 
-from ..editor import Editor
 from .menu_tools import menu_tools
+
+if TYPE_CHECKING:
+    from ..editor import Editor
 
 
 class CanvasMenuBar(QMenuBar):
-    _editor: Editor
+    _editor: "Editor"
 
-    def __init__(self, *args, editor: Editor, **kwargs) -> None:
+    def __init__(self, *args, editor: "Editor", **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self._editor = editor
 


### PR DESCRIPTION
Central widget should get switchable layouts to jump from drawing to solving tasks. Switching implies switching widgets which leads to completely new ways to interact with central widget. Currently, task is defined as follows:

1.  TeX label - text of the task
2. Canvas with predrawn, imputable molecules (and possibly reaction arrows / conditions). These molecules are drawn in alpha_atom/line classes
3. Smaller interactive canvases and labels to insert user's answers. These widgets will be placed as blank spaces in tasks

To switch between layouts (i.e. switching between task solving and simple drawing) user should use menu bar